### PR TITLE
Fix of miDebuggerAddress snippet

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
               "request": "launch",
               "program": "^\"\\${config:rrcfg-tools.bin}\"",
               "args": [],
-              "miDebuggerServerAddress": "^\"\\${config:rrcfg-tools.address}:\\${config:rrcfg-tools.port}\"",
+              "miDebuggerServerAddress": "^\"\\${config:rrcfg-tools.hostname}:\\${config:rrcfg-tools.port}\"",
               "stopAtEntry": true,
               "cwd": "^\"\\${config:rrcfg-tools.cwd}\"",
               "environment": [],


### PR DESCRIPTION
Used the old .address instead of the more appropriate .hostname