### PR TITLE
Closes issue #41

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,13 @@
             "type": "string",
             "description": "Full path of rr binary (defaults to 'rr')",
             "default": "rr"
+          },
+          "rrcfg-tools.trace-path-pick": {
+            "type": "string",
+            "default": "RR_TRACE_DIR",
+            "description": "Setting for defining how to input trace directory",
+            "enum": ["RR_TRACE_DIR", "User provided"],
+            "enumDescriptions": ["Shows list of recorded traces that exists in RR_TRACE_DIR which user gets to pick from", "User gets to type in full path to the trace directory at start of debug"]
           }
         }
       }


### PR DESCRIPTION
With this PR the user can either set RR_TRACE_DIR or "User provided" in the configuration. This means either rr handles the listing of the traces (by `rr ls -l -t -r`) or the user is requested to write the full path to the trace directory. 